### PR TITLE
Install newer npm on travis to make tests pass on 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
+before_install:
+  - npm install -g npm@~1.4.6


### PR DESCRIPTION
Sorry, I know these are minor details that doesn't really matter, but I like those green badges ;-)

See http://tech.vg.no/2014/05/30/npm-travis-node-and-the-caret-operator/ for an explanation.
